### PR TITLE
Fix catalog page rendering duplication

### DIFF
--- a/index.html
+++ b/index.html
@@ -873,7 +873,7 @@
 
         renderCategoryFilters();
         renderProducts();
-    </script>
+    <\/script>
 </body>
 </html>`;
 


### PR DESCRIPTION
## Summary
- escape the closing script tag inside the generated catalog template so the admin script no longer breaks the live page
- ensure the exported HTML download keeps its embedded script intact while preventing duplicated markup on the main view

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e471373abc8332a1c2715f3fcb2a46