### PR TITLE
Fix admin tab script execution

### DIFF
--- a/index.html
+++ b/index.html
@@ -589,7 +589,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Amazonia Concrete - Catálogo</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.tailwindcss.com"></scr${'ipt>'}
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; }
@@ -873,7 +873,7 @@
 
         renderCategoryFilters();
         renderProducts();
-    </script>
+    </scr${'ipt>'}
 </body>
 </html>`;
 


### PR DESCRIPTION
## Summary
- ensure every closing `<script>` tag inside the downloadable catalog template is escaped so the inline admin/catalog script parses correctly
- keep the generated catalog HTML intact when saving so the exported file retains valid script tags

## Testing
- python playwright script to load the page and open the admin tab

------
https://chatgpt.com/codex/tasks/task_e_68e471373abc8332a1c2715f3fcb2a46